### PR TITLE
get application config properly

### DIFF
--- a/src/ZfcBase/Module/ModuleAbstract.php
+++ b/src/ZfcBase/Module/ModuleAbstract.php
@@ -66,7 +66,12 @@ abstract class ModuleAbstract implements
         if(empty($config[$this->getNamespace()][$namespace])) {
             return array();
         }
-        return $config[$this->getNamespace()][$namespace]->toArray();
+
+        if (is_array($config[$this->getNamespace()][$namespace])) {
+            return $config[$this->getNamespace()][$namespace];
+        } else {
+            return $config[$this->getNamespace()][$namespace]->toArray();
+        }
     }
     
     /**


### PR DESCRIPTION
For whatever reason `$e->getParam('config')` no longer returns the configuration.
