### PR TITLE
Refactor AbstractDbMapper

### DIFF
--- a/src/ZfcBase/Mapper/AbstractDbMapper.php
+++ b/src/ZfcBase/Mapper/AbstractDbMapper.php
@@ -56,6 +56,11 @@ abstract class AbstractDbMapper extends EventProvider
     private $slaveSql;
 
     /**
+     * @var string
+     */
+    protected $tableName;
+
+    /**
      * @var boolean
      */
     private $isInitialized = false;
@@ -177,6 +182,14 @@ abstract class AbstractDbMapper extends EventProvider
         $statement = $sql->prepareStatementForSqlObject($delete);
 
         return $statement->execute();
+    }
+
+    /**
+     * @return string
+     */
+    protected function getTableName()
+    {
+        return $this->tableName;
     }
 
     /**


### PR DESCRIPTION
Changes:
- all methods performing database operations are now protected (select, insert, update)
- select renamed to getSelect
- selectWith renamed to select for consistency
- added delete
- database operations now no longer create a new Sql object for every operation - a Sql object prototype is used instead, and this object is used to create Select/Insert/Update/Delete objects where applicable

Based on the following resources:
- https://github.com/ZF-Commons/ZfcBase/wiki/AbstractDbMapper-Notes
- https://gist.github.com/3279166
