### PR TITLE
AbstractDbMapper::getSelect should use default table name if no $table argument given

### DIFF
--- a/src/ZfcBase/Mapper/AbstractDbMapper.php
+++ b/src/ZfcBase/Mapper/AbstractDbMapper.php
@@ -97,7 +97,7 @@ abstract class AbstractDbMapper extends EventProvider
     protected function getSelect($table = null)
     {
         $this->initialize();
-        return $this->getSlaveSql()->select($table);
+        return $this->getSlaveSql()->select($table ?: $this->getTableName());
     }
 
     /**


### PR DESCRIPTION
Currently, within a mapper extending AbstractDbMapper we have to do something like this:

```
// As Argument
$this->getSelect($this->getTableName());

// Add table directly
$this->getSelect()->from($this->getTableName());
```

It would be simpler if `getSelect` did this automatically. 
